### PR TITLE
Fix failure to connect with ssh from windows 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 # nuget package placeholder
 *.here
+/cmake-3.12.3-win64-x64
+/deps


### PR DESCRIPTION
After debugging the issue with a small c++ program, it appeared that
libssh2 was getting an error when calling windows api BCryptImportKeyPair.

The root cause seems to be linked to May'19 update of Windows (1903)
according to https://github.com/libssh2/libssh2/issues/388.

Update libssh2 to latest and integrate upstream fix not yet merged:
https://github.com/libssh2/libssh2/pull/484

After rebuilding libgit2sharp-ssh.nativebinaries nuget with this change, git
over ssh is working again.